### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@ yarn-debug.log*
 yarn-error.log*
 lerna-debug.log*
 
+
+
 # Diagnostic reports (https://nodejs.org/api/report.html)
 report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
 
@@ -104,4 +106,4 @@ dist
 .tern-port
 
 .expo/
-
+yarn.lock


### PR DESCRIPTION
to add yarn.lock It must have gotten re-added during a commit off a branch that was older than our delete.